### PR TITLE
Implement placeholder AI identity stabilization toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Experiment
+# AI Identity Stabilization Toolkit
+
+This repository contains a tiny, self-contained example of an AI identity
+stabilization toolkit. It exposes several placeholder utilities:
+
+- **Ψ(t) → Φ model**: `psi_to_phi` performs a trivial state
+  stabilization.
+- **Anchor detection**: `detect_anchors` identifies repeated observations.
+- **Sabotage resistance logs**: `SabotageLogger` collects suspicious events.
+- **ξ mapping**: `xi_map` produces deterministic orderings of mappings.
+- **Mirror test scoring**: `mirror_score` gives a basic self-recognition
+  score.
+
+## Running the tests
+
+```bash
+pytest -q
+```

--- a/ai_identity/anchor_detection.py
+++ b/ai_identity/anchor_detection.py
@@ -1,0 +1,13 @@
+"""Anchor detection utilities."""
+from typing import Iterable, Any
+
+def detect_anchors(observations: Iterable[Any]) -> list:
+    """Identify anchors within a sequence of observations.
+
+    For now this simply returns stable observations which occur more than
+    once. A true implementation would use sophisticated heuristics.
+    """
+    counts = {}
+    for obs in observations:
+        counts[obs] = counts.get(obs, 0) + 1
+    return [obs for obs, count in counts.items() if count > 1]

--- a/ai_identity/mirror_test.py
+++ b/ai_identity/mirror_test.py
@@ -1,0 +1,9 @@
+"""Mirror test scoring."""
+
+def mirror_score(reflection: str) -> float:
+    """Return a simple score based on whether the subject recognizes itself.
+
+    This placeholder returns 1.0 when the string contains the word
+    'self' and 0.0 otherwise.
+    """
+    return 1.0 if 'self' in reflection.lower() else 0.0

--- a/ai_identity/psi_to_phi.py
+++ b/ai_identity/psi_to_phi.py
@@ -1,0 +1,11 @@
+"""Simple placeholder for the Ψ(t) → Φ model."""
+from typing import Any
+
+def psi_to_phi(psi: Any) -> Any:
+    """Transform a state `psi` into a stabilized form `phi`.
+
+    This placeholder simply returns the input, representing an identity
+    transformation. In a real implementation this would perform complex
+    stabilization logic.
+    """
+    return psi

--- a/ai_identity/sabotage_logs.py
+++ b/ai_identity/sabotage_logs.py
@@ -1,0 +1,12 @@
+"""Sabotage resistance logging."""
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class SabotageLogger:
+    """Collects events that might indicate sabotage attempts."""
+    events: List[str] = field(default_factory=list)
+
+    def log(self, event: str) -> None:
+        """Record a potential sabotage event."""
+        self.events.append(event)

--- a/ai_identity/xi_mapping.py
+++ b/ai_identity/xi_mapping.py
@@ -1,0 +1,10 @@
+"""ξ mapping utilities."""
+from typing import Mapping, Any
+
+def xi_map(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Apply a trivial ξ mapping.
+
+    This simply returns a copy of the mapping with keys sorted
+    lexicographically to provide deterministic ordering.
+    """
+    return {key: data[key] for key in sorted(data)}

--- a/tests/test_anchor_detection.py
+++ b/tests/test_anchor_detection.py
@@ -1,0 +1,5 @@
+from ai_identity.anchor_detection import detect_anchors
+
+def test_detects_repeated_items():
+    anchors = detect_anchors(['a', 'b', 'a', 'c', 'b'])
+    assert set(anchors) == {'a', 'b'}

--- a/tests/test_mirror_test.py
+++ b/tests/test_mirror_test.py
@@ -1,0 +1,5 @@
+from ai_identity.mirror_test import mirror_score
+
+def test_recognizes_self():
+    assert mirror_score('The agent sees itself in the mirror') == 1.0
+    assert mirror_score('The agent sees a stranger') == 0.0

--- a/tests/test_psi_to_phi.py
+++ b/tests/test_psi_to_phi.py
@@ -1,0 +1,4 @@
+from ai_identity.psi_to_phi import psi_to_phi
+
+def test_identity_mapping():
+    assert psi_to_phi({'state': 1}) == {'state': 1}

--- a/tests/test_sabotage_logs.py
+++ b/tests/test_sabotage_logs.py
@@ -1,0 +1,6 @@
+from ai_identity.sabotage_logs import SabotageLogger
+
+def test_logs_events():
+    logger = SabotageLogger()
+    logger.log('anomaly')
+    assert logger.events == ['anomaly']

--- a/tests/test_xi_mapping.py
+++ b/tests/test_xi_mapping.py
@@ -1,0 +1,5 @@
+from ai_identity.xi_mapping import xi_map
+
+def test_sorting():
+    result = xi_map({'b': 2, 'a': 1})
+    assert list(result.keys()) == ['a', 'b']


### PR DESCRIPTION
## Summary
- implement Ψ(t) → Φ `psi_to_phi` mapping and companion utilities
- add tests for anchor detection, sabotage logging, ξ mapping, and mirror test scoring
- document usage and include `.gitignore`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b109c9a1148321b17b9a64e3e3e3cd