### PR TITLE
Improve Git Bash compatibility for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,27 @@
-import os
+"""Test configuration helpers.
+
+This module adjusts ``sys.path`` so that the package under test can be
+imported when the test suite is invoked from arbitrary working directories.
+
+Git Bash on Windows sometimes launches ``pytest`` from a different path than
+expected, which means the repository root might not be on ``sys.path``.  Using
+``pathlib`` to resolve the project root provides a robust, cross-platform
+solution.
+"""
+
+from pathlib import Path
 import sys
 
-# Ensure the repository root is on sys.path for imports when running tests
-# from any working directory, including Git Bash environments on Windows.
-ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if ROOT not in sys.path:
-    sys.path.insert(0, ROOT)
+# Determine the absolute path to the repository root in a platform-agnostic
+# way. ``Path.resolve`` handles any ``..`` segments and normalises the drive
+# letter on Windows so comparisons succeed regardless of how the path was
+# invoked.
+ROOT = Path(__file__).resolve().parent.parent
+ROOT_STR = str(ROOT)
+
+# Prepend the resolved root to ``sys.path`` if it's not already present.  This
+# allows ``import ai_identity`` to succeed even when tests are executed from
+# outside the repository (e.g. from a Git Bash shell opened elsewhere).
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)
+


### PR DESCRIPTION
## Summary
- resolve project root with `pathlib` in tests
- ensure test suite finds package when run from Git Bash on Windows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10c4805f88321ad33ea6c9708233b