### PR TITLE
Expand test suite with richer pytest cases

### DIFF
--- a/tests/test_anchor_detection.py
+++ b/tests/test_anchor_detection.py
@@ -1,5 +1,31 @@
+import pytest
+
 from ai_identity.anchor_detection import detect_anchors
 
-def test_detects_repeated_items():
-    anchors = detect_anchors(['a', 'b', 'a', 'c', 'b'])
-    assert set(anchors) == {'a', 'b'}
+
+@pytest.mark.parametrize(
+    "observations, expected",
+    [
+        (['a', 'b', 'a', 'c', 'b'], {'a', 'b'}),
+        ([1, 2, 3], set()),
+        ([], set()),
+    ],
+)
+def test_detect_anchors(observations, expected):
+    """Detect anchors when items repeat and ignore unique items."""
+    assert set(detect_anchors(observations)) == expected
+
+
+def test_detect_anchors_rejects_unhashable():
+    """Unhashable items should raise ``TypeError`` when counted."""
+    with pytest.raises(TypeError):
+        detect_anchors([[1], [1]])
+
+
+def test_detect_anchors_handles_objects():
+    """The detection works with arbitrary hashable objects."""
+    class Item:
+        pass
+
+    obj = Item()
+    assert detect_anchors([obj, obj]) == [obj]

--- a/tests/test_mirror_test.py
+++ b/tests/test_mirror_test.py
@@ -1,5 +1,17 @@
+import pytest
+
 from ai_identity.mirror_test import mirror_score
 
-def test_recognizes_self():
-    assert mirror_score('The agent sees itself in the mirror') == 1.0
-    assert mirror_score('The agent sees a stranger') == 0.0
+
+@pytest.mark.parametrize(
+    "reflection, expected",
+    [
+        ("The agent sees itself in the mirror", 1.0),
+        ("The agent sees SELF awareness", 1.0),
+        ("The agent sees a stranger", 0.0),
+        ("No reflection here", 0.0),
+    ],
+)
+def test_mirror_score(reflection, expected):
+    """Return ``1.0`` when the subject recognises itself."""
+    assert mirror_score(reflection) == expected

--- a/tests/test_psi_to_phi.py
+++ b/tests/test_psi_to_phi.py
@@ -1,4 +1,15 @@
+import pytest
+
 from ai_identity.psi_to_phi import psi_to_phi
 
-def test_identity_mapping():
-    assert psi_to_phi({'state': 1}) == {'state': 1}
+
+@pytest.mark.parametrize("psi", [
+    {"state": 1},
+    [1, 2, 3],
+    "text",
+])
+def test_identity_mapping_returns_same_object(psi):
+    """The transformation should return the same object instance."""
+    phi = psi_to_phi(psi)
+    assert phi == psi
+    assert phi is psi

--- a/tests/test_sabotage_logs.py
+++ b/tests/test_sabotage_logs.py
@@ -1,6 +1,17 @@
 from ai_identity.sabotage_logs import SabotageLogger
 
-def test_logs_events():
+
+def test_logs_multiple_events():
+    """Logged events are appended in order."""
     logger = SabotageLogger()
     logger.log('anomaly')
-    assert logger.events == ['anomaly']
+    logger.log('intrusion')
+    assert logger.events == ['anomaly', 'intrusion']
+
+
+def test_loggers_are_isolated():
+    """Separate instances maintain independent event lists."""
+    first = SabotageLogger()
+    second = SabotageLogger()
+    first.log('issue')
+    assert second.events == []

--- a/tests/test_xi_mapping.py
+++ b/tests/test_xi_mapping.py
@@ -1,5 +1,23 @@
+import pytest
+
 from ai_identity.xi_mapping import xi_map
 
-def test_sorting():
-    result = xi_map({'b': 2, 'a': 1})
-    assert list(result.keys()) == ['a', 'b']
+
+@pytest.mark.parametrize(
+    "data, expected_order",
+    [
+        ({'b': 2, 'a': 1}, ['a', 'b']),
+        ({'c': 3, 'b': 2, 'a': 1}, ['a', 'b', 'c']),
+    ],
+)
+def test_sorting(data, expected_order):
+    """Keys are sorted lexicographically in the returned mapping."""
+    result = xi_map(data)
+    assert list(result.keys()) == expected_order
+
+
+def test_returns_new_mapping():
+    """The original mapping is not modified in-place."""
+    original = {'b': 2, 'a': 1}
+    result = xi_map(original)
+    assert result is not original


### PR DESCRIPTION
## Summary
- Expand anchor detection tests with parametric cases and object handling
- Add comprehensive mirror test cases for recognition scoring
- Broaden psi→phi, sabotage logs, and xi mapping tests for richer coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11217aa6883219226f3f7b1ba3b8e