### PR TITLE
Add epistemic tension utility and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ stabilization toolkit. It exposes several placeholder utilities:
 - **ξ mapping**: `xi_map` produces deterministic orderings of mappings.
 - **Mirror test scoring**: `mirror_score` gives a basic self-recognition
   score.
+- **Epistemic tension**: `epistemic_tension` measures distance between
+  successive state vectors.
 
 ## Running the tests
 

--- a/ai_identity/epistemic_tension.py
+++ b/ai_identity/epistemic_tension.py
@@ -1,0 +1,20 @@
+"""Epistemic tension computation."""
+from typing import Sequence
+import math
+
+def epistemic_tension(state_a: Sequence[float], state_b: Sequence[float]) -> float:
+    """Compute the L2 norm between two state vectors.
+
+    Parameters
+    ----------
+    state_a, state_b:
+        Sequences of numeric values representing successive state embeddings.
+
+    Returns
+    -------
+    float
+        The Euclidean distance between ``state_a`` and ``state_b``.
+    """
+    if len(state_a) != len(state_b):
+        raise ValueError("state vectors must be the same length")
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(state_a, state_b)))

--- a/tests/test_epistemic_tension.py
+++ b/tests/test_epistemic_tension.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ai_identity.epistemic_tension import epistemic_tension
+
+
+def test_epistemic_tension_zero():
+    """Zero distance for identical states."""
+    assert epistemic_tension([0, 0], [0, 0]) == 0.0
+
+
+def test_epistemic_tension_known_values():
+    """Distance matches known Euclidean value."""
+    assert epistemic_tension([0, 0], [3, 4]) == 5.0
+
+
+def test_epistemic_tension_mismatched_length():
+    """Mismatched vector lengths raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        epistemic_tension([1, 2], [1])


### PR DESCRIPTION
## Summary
- add `epistemic_tension` helper for computing Euclidean distance between state vectors
- document new capability in README
- cover edge cases and expected values with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1153e79b48321b615ae02125b22fe