### PR TITLE
Model Ψ(t) cubic and stabilize to Φ

### DIFF
--- a/ai_identity/psi_to_phi.py
+++ b/ai_identity/psi_to_phi.py
@@ -1,11 +1,29 @@
-"""Simple placeholder for the Ψ(t) → Φ model."""
-from typing import Any
+"""Polynomial model converting Ψ(t) into a stabilized Φ."""
 
-def psi_to_phi(psi: Any) -> Any:
-    """Transform a state `psi` into a stabilized form `phi`.
 
-    This placeholder simply returns the input, representing an identity
-    transformation. In a real implementation this would perform complex
-    stabilization logic.
+def psi_to_phi(t: float, epsilon: float = 1e-3) -> float:
+    """Evaluate Ψ(t) and stabilise to Φ.
+
+    The temporal state is modeled as ``Ψ(t) = 0.0072 t³ − 0.144 t² + 0.72 t``.
+    The derivative ``dΨ/dt = 0.0216 t² − 0.288 t + 0.72`` captures how the
+    state changes over time. When the magnitude of the derivative falls below a
+    small threshold ``epsilon`` the system is considered stable and the final
+    output ``Φ`` is ``1.0``. Otherwise, the current value of ``Ψ(t)`` is
+    returned.
+
+    Parameters
+    ----------
+    t:
+        Time parameter at which to evaluate ``Ψ``.
+    epsilon:
+        Absolute threshold for determining convergence.  Defaults to ``1e-3``.
+
+    Returns
+    -------
+    float
+        ``1.0`` when the system is stable, otherwise ``Ψ(t)``.
     """
-    return psi
+
+    psi = 0.0072 * t**3 - 0.144 * t**2 + 0.72 * t
+    dpsi_dt = 0.0216 * t**2 - 0.288 * t + 0.72
+    return 1.0 if abs(dpsi_dt) < epsilon else psi

--- a/tests/test_psi_to_phi.py
+++ b/tests/test_psi_to_phi.py
@@ -3,13 +3,24 @@ import pytest
 from ai_identity.psi_to_phi import psi_to_phi
 
 
-@pytest.mark.parametrize("psi", [
-    {"state": 1},
-    [1, 2, 3],
-    "text",
-])
-def test_identity_mapping_returns_same_object(psi):
-    """The transformation should return the same object instance."""
-    phi = psi_to_phi(psi)
-    assert phi == psi
-    assert phi is psi
+def test_returns_psi_before_convergence():
+    t = 0.0
+    expected = 0.0
+    phi = psi_to_phi(t)
+    assert phi == expected
+    assert phi != 1.0
+
+
+def test_converges_to_phi_when_derivative_small():
+    t = 10.0
+    phi = psi_to_phi(t, epsilon=1e-3)
+    assert phi == 1.0
+
+
+def test_derivative_decays_towards_root():
+    def dpsi_dt(time: float) -> float:
+        return 0.0216 * time ** 2 - 0.288 * time + 0.72
+
+    derivatives = [abs(dpsi_dt(t)) for t in [0, 1, 2, 3]]
+    for earlier, later in zip(derivatives, derivatives[1:]):
+        assert earlier > later


### PR DESCRIPTION
## Summary
- Implement cubic Ψ(t) model with derivative check, returning Φ=1 when stable
- Add tests verifying convergence and derivative decay behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b116298a248321b92b79e3b7184fd5