### PR TITLE
Add xi distance metrics and coherence utility

### DIFF
--- a/ai_identity/epistemic_tension.py
+++ b/ai_identity/epistemic_tension.py
@@ -1,20 +1,107 @@
-"""Epistemic tension computation."""
-from typing import Sequence
+"""Epistemic tension computation utilities.
+
+This module exposes a generic :func:`xi` function for measuring the
+"epistemic tension" between successive state embeddings.  Two distance
+metrics are provided:
+
+``l2``
+    Standard Euclidean distance between vectors.
+
+``cosine``
+    Cosine distance ``1 - cos(θ)`` where ``θ`` is the angle between the
+    vectors.
+
+Additionally, :func:`xi_series_to_coherence` converts a series of ξ values
+into coherence (§) scores as described in Appendix A of the specification.
+The coherence after each step is ``1 / (1 + Σ ξ)``.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, List
 import math
 
-def epistemic_tension(state_a: Sequence[float], state_b: Sequence[float]) -> float:
-    """Compute the L2 norm between two state vectors.
+
+def xi(
+    state_a: Sequence[float],
+    state_b: Sequence[float],
+    *,
+    metric: str = "l2",
+) -> float:
+    """Compute epistemic tension between two state vectors.
 
     Parameters
     ----------
     state_a, state_b:
-        Sequences of numeric values representing successive state embeddings.
+        Sequences of numeric values representing successive state
+        embeddings.  Both sequences must be of equal length.
+    metric:
+        The distance metric to use.  Supported values are ``"l2"`` for
+        Euclidean distance and ``"cosine"`` for cosine distance.
 
     Returns
     -------
     float
-        The Euclidean distance between ``state_a`` and ``state_b``.
+        The distance between ``state_a`` and ``state_b`` under the
+        requested metric.
     """
+
     if len(state_a) != len(state_b):
         raise ValueError("state vectors must be the same length")
-    return math.sqrt(sum((a - b) ** 2 for a, b in zip(state_a, state_b)))
+
+    if metric == "l2":
+        return math.sqrt(sum((a - b) ** 2 for a, b in zip(state_a, state_b)))
+
+    if metric == "cosine":
+        dot = sum(a * b for a, b in zip(state_a, state_b))
+        norm_a = math.sqrt(sum(a * a for a in state_a))
+        norm_b = math.sqrt(sum(b * b for b in state_b))
+        if norm_a == 0 or norm_b == 0:
+            raise ValueError("state vectors must be non-zero for cosine metric")
+        return 1 - (dot / (norm_a * norm_b))
+
+    raise ValueError(f"unsupported metric '{metric}'")
+
+
+def epistemic_tension(
+    state_a: Sequence[float], state_b: Sequence[float], *, metric: str = "l2"
+) -> float:
+    """Backward compatible wrapper around :func:`xi`.
+
+    ``epistemic_tension(a, b)`` is equivalent to ``xi(a, b, metric="l2")`` by
+    default, but the ``metric`` parameter is exposed for completeness.
+    """
+
+    return xi(state_a, state_b, metric=metric)
+
+
+def xi_series_to_coherence(xi_series: Iterable[float]) -> List[float]:
+    """Convert a series of ξ values into coherence (§) scores.
+
+    The coherence after each step ``k`` is defined as::
+
+        §_k = 1 / (1 + Σ_{i=1..k} ξ_i)
+
+    Parameters
+    ----------
+    xi_series:
+        Iterable of non-negative ξ values.
+
+    Returns
+    -------
+    list of float
+        Coherence score after each successive ξ.
+    """
+
+    coherence: List[float] = []
+    cumulative = 0.0
+    for xi_value in xi_series:
+        if xi_value < 0:
+            raise ValueError("ξ values must be non-negative")
+        cumulative += xi_value
+        coherence.append(1.0 / (1.0 + cumulative))
+    return coherence
+
+
+__all__ = ["xi", "epistemic_tension", "xi_series_to_coherence"]
+

--- a/tests/test_epistemic_tension.py
+++ b/tests/test_epistemic_tension.py
@@ -1,19 +1,41 @@
 import pytest
 
-from ai_identity.epistemic_tension import epistemic_tension
+from ai_identity.epistemic_tension import (
+    epistemic_tension,
+    xi,
+    xi_series_to_coherence,
+)
 
 
-def test_epistemic_tension_zero():
-    """Zero distance for identical states."""
-    assert epistemic_tension([0, 0], [0, 0]) == 0.0
+def test_xi_l2_known_values():
+    """L2 metric matches known Euclidean distance."""
+    assert xi([0, 0], [3, 4]) == 5.0
 
 
-def test_epistemic_tension_known_values():
-    """Distance matches known Euclidean value."""
+def test_xi_cosine_known_values():
+    """Cosine metric returns 0 for identical vectors and 1 for orthogonal ones."""
+    assert xi([1, 0], [1, 0], metric="cosine") == pytest.approx(0.0)
+    assert xi([1, 0], [0, 1], metric="cosine") == pytest.approx(1.0)
+
+
+def test_xi_mismatched_length():
+    """Mismatched vector lengths raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        xi([1, 2], [1])
+
+
+def test_epistemic_tension_wrapper():
+    """`epistemic_tension` wraps :func:`xi` using the L2 metric."""
     assert epistemic_tension([0, 0], [3, 4]) == 5.0
 
 
-def test_epistemic_tension_mismatched_length():
-    """Mismatched vector lengths raise ``ValueError``."""
-    with pytest.raises(ValueError):
-        epistemic_tension([1, 2], [1])
+def test_xi_series_to_coherence_from_vectors():
+    """Coherence series computed from ξ values of synthetic vectors."""
+    vectors = [[1, 0], [0, 1], [0, 2]]
+    xi_values = [xi(vectors[i], vectors[i + 1]) for i in range(len(vectors) - 1)]
+    expected = [
+        1 / (1 + xi_values[0]),
+        1 / (1 + xi_values[0] + xi_values[1]),
+    ]
+    assert xi_series_to_coherence(xi_values) == pytest.approx(expected)
+


### PR DESCRIPTION
## Summary
- Extend epistemic tension module with generic `xi` supporting L2 and cosine distances
- Add helper `xi_series_to_coherence` to derive coherence scores
- Cover new functionality with synthetic vector tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11636f3888321beb3fc8c4b26b124