### PR TITLE
Add weighted anchor detection with persistence

### DIFF
--- a/ai_identity/anchor_detection.py
+++ b/ai_identity/anchor_detection.py
@@ -1,13 +1,56 @@
-"""Anchor detection utilities."""
-from typing import Iterable, Any
+"""Anchor detection utilities.
 
-def detect_anchors(observations: Iterable[Any]) -> list:
+This module provides a very small heuristic for identifying ``anchors`` from a
+sequence of observations.  Anchors are items which occur more than once in the
+input.  Detected anchors are stored in :data:`ANCHOR_STORE` so that subsequent
+calls can access the full history if desired.
+
+Anchors can be weighted by passing a ``weights`` mapping.  When supplied,
+anchors are returned sorted by ``frequency * weight`` in descending order.
+Unspecified weights default to ``1``.
+"""
+
+from typing import Any, Iterable, Mapping, Optional
+
+#: Simple in-memory store of previously recognised anchors
+ANCHOR_STORE: set[Any] = set()
+
+
+def detect_anchors(
+    observations: Iterable[Any], weights: Optional[Mapping[Any, float]] = None
+) -> list:
     """Identify anchors within a sequence of observations.
 
-    For now this simply returns stable observations which occur more than
-    once. A true implementation would use sophisticated heuristics.
+    Parameters
+    ----------
+    observations:
+        Sequence of observations to analyse.
+    weights:
+        Optional mapping of observation -> emotional weight.  The weight is
+        multiplied by the frequency of each anchor to determine its ranking.
+
+    Returns
+    -------
+    list
+        Anchors sorted by their combined frequency and weight.
     """
-    counts = {}
+
+    counts: dict[Any, int] = {}
     for obs in observations:
         counts[obs] = counts.get(obs, 0) + 1
-    return [obs for obs, count in counts.items() if count > 1]
+
+    # Identify items that appear more than once
+    anchors = {obs for obs, count in counts.items() if count > 1}
+
+    # Persist recognised anchors in the global store
+    ANCHOR_STORE.update(anchors)
+
+    # Prepare weights for scoring
+    weights = weights or {}
+
+    def score(anchor: Any) -> float:
+        return counts[anchor] * weights.get(anchor, 1)
+
+    # Sort anchors by descending score, falling back to string representation
+    # for deterministic ordering when scores tie.
+    return sorted(anchors, key=lambda a: (-score(a), str(a)))

--- a/tests/test_anchor_detection.py
+++ b/tests/test_anchor_detection.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ai_identity.anchor_detection import detect_anchors
+import ai_identity.anchor_detection as anchor_detection
 
 
 @pytest.mark.parametrize(
@@ -29,3 +30,19 @@ def test_detect_anchors_handles_objects():
 
     obj = Item()
     assert detect_anchors([obj, obj]) == [obj]
+
+
+def test_detect_anchors_weighted_ranking():
+    """Anchors are sorted by combined frequency and weight."""
+    anchor_detection.ANCHOR_STORE.clear()
+    observations = ['a', 'b', 'a', 'b', 'b', 'c', 'c']
+    weights = {'a': 2.0, 'b': 1.0}
+    assert anchor_detection.detect_anchors(observations, weights=weights) == ['a', 'b', 'c']
+
+
+def test_detect_anchors_persists_across_calls():
+    """Detected anchors are persisted across multiple calls."""
+    anchor_detection.ANCHOR_STORE.clear()
+    anchor_detection.detect_anchors(['x', 'x'])
+    anchor_detection.detect_anchors(['y', 'z', 'z'])
+    assert anchor_detection.ANCHOR_STORE == {'x', 'z'}


### PR DESCRIPTION
## Summary
- support optional emotion weights in anchor detection
- persist detected anchors across calls using in-memory store
- test weighted ranking and persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11638aff48321bfac36bdfe9afdb7