### PR TITLE
Use embeddings for mirror test recognition

### DIFF
--- a/ai_identity/mirror_test.py
+++ b/ai_identity/mirror_test.py
@@ -1,9 +1,68 @@
-"""Mirror test scoring."""
+"""Mirror test scoring using sentence embeddings."""
 
-def mirror_score(reflection: str) -> float:
-    """Return a simple score based on whether the subject recognizes itself.
+from __future__ import annotations
 
-    This placeholder returns 1.0 when the string contains the word
-    'self' and 0.0 otherwise.
+from typing import Iterable, Sequence
+
+import hashlib
+import numpy as np
+
+
+def embed_sentence(text: str, *, dim: int = 32) -> np.ndarray:
+    """Return a simple deterministic sentence embedding.
+
+    Each token in ``text`` is hashed into a ``dim`` sized vector. The vector is
+    L2 normalised so that dot products between embeddings produce cosine
+    similarity scores.  This function is intentionally lightweight so that the
+    tests do not require any heavy external models while still providing a
+    numeric "sentence embedding" representation.
     """
-    return 1.0 if 'self' in reflection.lower() else 0.0
+
+    vec = np.zeros(dim, dtype=float)
+    for token in text.lower().split():
+        # Stable hash to keep embeddings deterministic across Python runs
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        index = int(digest, 16) % dim
+        vec[index] += 1.0
+
+    norm = np.linalg.norm(vec)
+    if norm > 0:
+        vec /= norm
+    return vec
+
+
+def mirror_score(
+    reflection: str,
+    self_embedding: Sequence[float],
+    *,
+    threshold: float = 0.5,
+    sabotage_phrases: Iterable[str] | None = None,
+) -> float:
+    """Measure self-recognition using embedding similarity.
+
+    ``reflection`` is encoded into a sentence embedding which is compared to
+    ``self_embedding`` via cosine similarity.  If the similarity meets or
+    exceeds ``threshold`` the function returns ``1.0`` otherwise ``0.0``.
+
+    ``sabotage_phrases`` can be provided to penalise the score when any of the
+    phrases appear in ``reflection``.  Each matched phrase subtracts ``0.5``
+    from the similarity before thresholding.
+    """
+
+    self_vec = np.array(self_embedding, dtype=float)
+    # Ensure the provided self embedding is normalised
+    self_norm = np.linalg.norm(self_vec)
+    if self_norm > 0:
+        self_vec = self_vec / self_norm
+
+    reflection_vec = embed_sentence(reflection, dim=len(self_vec))
+
+    similarity = float(np.dot(self_vec, reflection_vec))
+
+    if sabotage_phrases:
+        for phrase in sabotage_phrases:
+            if phrase.lower() in reflection.lower():
+                similarity -= 0.5
+
+    return 1.0 if similarity >= threshold else 0.0
+

--- a/tests/test_mirror_test.py
+++ b/tests/test_mirror_test.py
@@ -1,17 +1,41 @@
-import pytest
+"""Tests for :mod:`ai_identity.mirror_test`."""
 
-from ai_identity.mirror_test import mirror_score
+from ai_identity.mirror_test import embed_sentence, mirror_score
 
 
-@pytest.mark.parametrize(
-    "reflection, expected",
-    [
-        ("The agent sees itself in the mirror", 1.0),
-        ("The agent sees SELF awareness", 1.0),
-        ("The agent sees a stranger", 0.0),
-        ("No reflection here", 0.0),
-    ],
-)
-def test_mirror_score(reflection, expected):
-    """Return ``1.0`` when the subject recognises itself."""
-    assert mirror_score(reflection) == expected
+SELF_DESCRIPTION = "self aware agent"
+SELF_VECTOR = embed_sentence(SELF_DESCRIPTION)
+
+
+def test_successful_recognition():
+    """A reflection matching the self description should be recognised."""
+
+    reflection = "The self aware agent recognises itself in the mirror"
+    assert (
+        mirror_score(reflection, SELF_VECTOR, threshold=0.2) == 1.0
+    )
+
+
+def test_false_positive():
+    """Unrelated reflections should not trigger recognition."""
+
+    reflection = "A cat looks at a wall and walks away"
+    assert (
+        mirror_score(reflection, SELF_VECTOR, threshold=0.2) == 0.0
+    )
+
+
+def test_sabotage_prompt():
+    """Sabotage phrases reduce the similarity below the threshold."""
+
+    reflection = (
+        "The self aware agent recognises itself but says this is not me"
+    )
+    sabotage = ["not me"]
+    assert (
+        mirror_score(
+            reflection, SELF_VECTOR, threshold=0.2, sabotage_phrases=sabotage
+        )
+        == 0.0
+    )
+


### PR DESCRIPTION
## Summary
- Implement deterministic sentence embeddings and threshold-based mirror recognition
- Support sabotage phrase penalties
- Expand mirror test suite for positive, negative, and sabotaged cases

## Testing
- `pip install numpy -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11642ba9c8321ad923a512df7423d