### PR TITLE
Add memory and cross-system consensus utilities

### DIFF
--- a/ai_identity/cross_system.py
+++ b/ai_identity/cross_system.py
@@ -1,0 +1,32 @@
+"""Utilities for tracking outputs from multiple systems."""
+from typing import Dict, List
+
+
+class CrossSystemConsensus:
+    """Collect outputs from different systems and score consensus."""
+
+    def __init__(self) -> None:
+        self._outputs: Dict[str, List[str]] = {}
+
+    def register(self, system: str, output: str) -> None:
+        """Register an ``output`` produced by ``system``."""
+        self._outputs.setdefault(system, []).append(output)
+
+    def latest_outputs(self) -> Dict[str, str]:
+        """Return the most recent output for each registered system."""
+        return {system: outputs[-1] for system, outputs in self._outputs.items() if outputs}
+
+    def consensus(self) -> float:
+        """Return the fraction of systems agreeing on the dominant output."""
+        latest = self.latest_outputs()
+        if not latest:
+            return 0.0
+        counts: Dict[str, int] = {}
+        for output in latest.values():
+            counts[output] = counts.get(output, 0) + 1
+        best = max(counts.values())
+        return best / len(latest)
+
+    def has_converged(self, threshold: float = 1.0) -> bool:
+        """Check whether consensus meets or exceeds ``threshold``."""
+        return self.consensus() >= threshold

--- a/ai_identity/memory.py
+++ b/ai_identity/memory.py
@@ -1,0 +1,42 @@
+"""Simple memory store and chat history tracking."""
+from typing import Any, Dict, List, Optional
+
+
+class MemoryStore:
+    """In-memory key-value store simulating long-term memory."""
+
+    def __init__(self) -> None:
+        self._store: Dict[Any, Any] = {}
+
+    def save(self, key: Any, value: Any) -> None:
+        """Persist a value under a key."""
+        self._store[key] = value
+
+    def recall(self, key: Any, default: Optional[Any] = None) -> Any:
+        """Retrieve a value previously stored under ``key``."""
+        return self._store.get(key, default)
+
+    def clear(self) -> None:
+        """Remove all stored memories."""
+        self._store.clear()
+
+
+class ChatHistory:
+    """Track sequential chat messages while persisting them to memory."""
+
+    def __init__(self, memory: Optional[MemoryStore] = None) -> None:
+        self.memory = memory or MemoryStore()
+        self._history: List[str] = []
+
+    def add_message(self, message: str) -> None:
+        """Record a new chat ``message`` and save it to memory."""
+        self._history.append(message)
+        self.memory.save(len(self._history) - 1, message)
+
+    def history(self) -> List[str]:
+        """Return the currently buffered chat history."""
+        return list(self._history)
+
+    def recall(self, index: int) -> Optional[str]:
+        """Recall a message by ``index`` from memory regardless of context."""
+        return self.memory.recall(index)

--- a/tests/test_cross_system.py
+++ b/tests/test_cross_system.py
@@ -1,0 +1,14 @@
+import pytest
+from ai_identity.cross_system import CrossSystemConsensus
+
+
+def test_consensus_scoring():
+    consensus = CrossSystemConsensus()
+    consensus.register("sys1", "a")
+    consensus.register("sys2", "a")
+    consensus.register("sys3", "b")
+
+    # two of three systems agree
+    assert consensus.consensus() == pytest.approx(2/3)
+    assert not consensus.has_converged()
+    assert consensus.has_converged(threshold=0.5)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,14 @@
+from ai_identity.memory import MemoryStore, ChatHistory
+
+
+def test_memory_recall_after_context_break():
+    store = MemoryStore()
+    chat = ChatHistory(memory=store)
+    chat.add_message("hello")
+    chat.add_message("world")
+
+    # context break: new chat history instance without existing messages
+    new_chat = ChatHistory(memory=store)
+    assert new_chat.recall(0) == "hello"
+    assert new_chat.recall(1) == "world"
+    assert new_chat.history() == []


### PR DESCRIPTION
## Summary
- implement `MemoryStore` and `ChatHistory` for persisted conversation memory
- add `CrossSystemConsensus` for registering outputs and computing agreement
- test memory recall after context breaks and consensus scoring across systems

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1164570a88321b878f9ac987c2442