### PR TITLE
Add real-time dashboard charts with dynamic controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
 
 <section id="psi-section">
   <h2>Ψ(t) → Φ Stabilisation</h2>
-  <label>t: <input type="number" id="psi-t" value="0" step="0.1" placeholder="e.g., 2.5" /></label>
-  <label>ε: <input type="number" id="psi-epsilon" value="0.001" step="0.0001" placeholder="e.g., 0.001" /></label>
+  <label>t: <input type="range" id="psi-t" min="0" max="10" step="0.1" value="0" oninput="document.getElementById('psi-t-val').textContent=this.value;runPsiToPhi();" /><span id="psi-t-val">0</span></label>
+  <label>ε: <input type="range" id="psi-epsilon" min="0.0001" max="0.01" step="0.0001" value="0.001" oninput="document.getElementById('psi-epsilon-val').textContent=this.value;runPsiToPhi();" /><span id="psi-epsilon-val">0.001</span></label>
   <button onclick="runPsiToPhi()">Compute Φ</button>
   <div class="output" id="psi-output"></div>
   <canvas id="psi-chart" height="100"></canvas>
@@ -24,7 +24,8 @@
 
 <section id="anchor-section">
   <h2>Anchor Detection</h2>
-  <label>Observations (comma separated):<br /><textarea id="anchor-observations" rows="2" placeholder="e.g., apple, banana, apple"></textarea></label>
+  <label>Observations (comma separated):<br /><textarea id="anchor-observations" rows="2" placeholder="e.g., apple, banana, apple" oninput="runAnchorDetection()"></textarea></label>
+  <label>Salience threshold: <input type="range" id="anchor-threshold" min="1" max="5" value="2" oninput="document.getElementById('anchor-threshold-val').textContent=this.value;runAnchorDetection();" /><span id="anchor-threshold-val">2</span></label>
   <button onclick="runAnchorDetection()">Detect Anchors</button>
   <div class="output" id="anchor-output"></div>
   <canvas id="anchor-chart" height="100"></canvas>
@@ -33,8 +34,15 @@
 <section id="sabotage-section">
   <h2>Sabotage Logger</h2>
   <label>Event: <input type="text" id="sabotage-event" placeholder="e.g., anomaly detected" /></label>
+  <label>Type:
+    <select id="sabotage-type">
+      <option value="sabotage">Sabotage</option>
+      <option value="resistance">Resistance</option>
+    </select>
+  </label>
   <button onclick="logSabotage()">Log Event</button>
   <div class="output" id="sabotage-log"></div>
+  <canvas id="sabotage-chart" height="100"></canvas>
 </section>
 
 <section id="xi-section">
@@ -54,12 +62,12 @@
 
 <section id="tension-section">
   <h2>Epistemic Tension</h2>
-  <label>State A (comma numbers):<br /><textarea id="tension-a" rows="2" placeholder="e.g., 1,0,0">1,0,0</textarea></label>
-  <label>State B (comma numbers):<br /><textarea id="tension-b" rows="2" placeholder="e.g., 0,1,0">0,1,0</textarea></label>
-  <select id="tension-metric"><option value="l2">L2</option><option value="cosine">Cosine</option></select>
+  <label>State A (comma numbers):<br /><textarea id="tension-a" rows="2" placeholder="e.g., 1,0,0" oninput="runTension()">1,0,0</textarea></label>
+  <label>State B (comma numbers):<br /><textarea id="tension-b" rows="2" placeholder="e.g., 0,1,0" oninput="runTension()">0,1,0</textarea></label>
+  <label>Perturbation intensity: <input type="range" id="tension-perturb" min="0" max="1" step="0.1" value="0" oninput="document.getElementById('tension-perturb-val').textContent=this.value;runTension();" /><span id="tension-perturb-val">0</span></label>
+  <select id="tension-metric" onchange="runTension()"><option value="l2">L2</option><option value="cosine">Cosine</option></select>
   <button onclick="runTension()">Compute ξ</button>
   <div class="output" id="tension-output"></div>
-  <button onclick="addXi()">Add ξ to Series</button>
   <canvas id="tension-chart" height="100"></canvas>
 </section>
 
@@ -103,7 +111,8 @@ function runAnchorDetection(){
   const obs = text.split(',').map(s => s.trim()).filter(Boolean);
   const counts = new Map();
   obs.forEach(o => counts.set(o, (counts.get(o) || 0) + 1));
-  const anchors = [...counts.entries()].filter(([, c]) => c > 1);
+  const threshold = parseInt(document.getElementById('anchor-threshold').value,10);
+  const anchors = [...counts.entries()].filter(([, c]) => c >= threshold);
   if(anchors.length === 0){
     document.getElementById('anchor-output').textContent = 'Anchors: none';
     if(window.anchorChart){window.anchorChart.destroy();window.anchorChart=null;}
@@ -123,13 +132,38 @@ function runAnchorDetection(){
 
 // Sabotage logger
 const sabotageEvents = [];
+const sabotageSeries = [];
+const resistanceSeries = [];
 function logSabotage(){
   const event = document.getElementById('sabotage-event').value;
+  const type = document.getElementById('sabotage-type').value;
   if(event){
-    sabotageEvents.push(`${new Date().toLocaleTimeString()}: ${event}`);
+    sabotageEvents.push(`${new Date().toLocaleTimeString()} [${type}] ${event}`);
     document.getElementById('sabotage-event').value='';
+    const lastSab = sabotageSeries[sabotageSeries.length-1] || 0;
+    const lastRes = resistanceSeries[resistanceSeries.length-1] || 0;
+    if(type==='sabotage'){
+      sabotageSeries.push(lastSab+1);
+      resistanceSeries.push(lastRes);
+    }else{
+      sabotageSeries.push(lastSab);
+      resistanceSeries.push(lastRes+1);
+    }
+    updateSabotageChart();
   }
   document.getElementById('sabotage-log').textContent = sabotageEvents.join('\n');
+}
+function updateSabotageChart(){
+  const labels = sabotageSeries.map((_,i)=>i+1);
+  if(window.sabotageChart) window.sabotageChart.destroy();
+  window.sabotageChart = new Chart(document.getElementById('sabotage-chart'),{
+    type:'line',
+    data:{labels:labels,datasets:[
+      {label:'Sabotage',data:sabotageSeries,borderColor:'red',fill:false},
+      {label:'Resistance',data:resistanceSeries,borderColor:'blue',fill:false}
+    ]},
+    options:{responsive:true,scales:{y:{beginAtZero:true}}}
+  });
 }
 
 // ξ mapping
@@ -209,15 +243,13 @@ function xi(stateA,stateB,metric){
 }
 function runTension(){
   const a=document.getElementById('tension-a').value.split(',').map(Number);
-  const b=document.getElementById('tension-b').value.split(',').map(Number);
+  const bInput=document.getElementById('tension-b').value.split(',').map(Number);
+  const intensity=parseFloat(document.getElementById('tension-perturb').value);
   const metric=document.getElementById('tension-metric').value;
+  const b=bInput.map(v=>v+intensity);
   const val=xi(a,b,metric);
   document.getElementById('tension-output').textContent=`ξ = ${val}`;
-  window.currentXi=val;
-}
-const xiSeries=[];
-function addXi(){
-  if(window.currentXi!==undefined){xiSeries.push(window.currentXi);}
+  xiSeries.push(val);
   const labels=xiSeries.map((_,i)=>i+1);
   let cumulative=0;const coherence=[];xiSeries.forEach(xi=>{cumulative+=xi;coherence.push(1/(1+cumulative));});
   if(window.tensionChart) window.tensionChart.destroy();
@@ -227,6 +259,7 @@ function addXi(){
     options:{responsive:true,scales:{y:{beginAtZero:true,max:1}}}
   });
 }
+const xiSeries=[];
 </script>
 <footer>© 2023 AI Identity Toolkit. All rights reserved.</footer>
 </body>


### PR DESCRIPTION
## Summary
- Add range sliders to Psi-to-Phi stabilisation for immediate chart updates
- Introduce anchor salience threshold slider and real-time bar chart updates
- Track sabotage vs resistance events with cumulative line chart
- Add perturbation intensity control and live coherence plotting for epistemic tension

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f4d3c6988321b49582d5353a8c67