### PR TITLE
Expose key utilities in ai_identity package init

### DIFF
--- a/ai_identity/__init__.py
+++ b/ai_identity/__init__.py
@@ -1,0 +1,18 @@
+"""Collection of utilities for modelling an agent's identity and stability."""
+
+from .psi_to_phi import psi_to_phi
+from .anchor_detection import detect_anchors
+from .sabotage_logs import SabotageLogger
+from .xi_mapping import xi_map
+from .mirror_test import mirror_score
+from .epistemic_tension import xi, epistemic_tension
+
+__all__ = [
+    "psi_to_phi",
+    "detect_anchors",
+    "SabotageLogger",
+    "xi_map",
+    "mirror_score",
+    "xi",
+    "epistemic_tension",
+]


### PR DESCRIPTION
## Summary
- add package-level docstring and convenience imports
- export common utilities like psi_to_phi, detect_anchors, mirror_score, and epistemic_tension

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b737787184832193c5cd9e63adb31a