### PR TITLE
Add reset method to CrossSystemConsensus

### DIFF
--- a/ai_identity/cross_system.py
+++ b/ai_identity/cross_system.py
@@ -3,7 +3,11 @@ from typing import Dict, List
 
 
 class CrossSystemConsensus:
-    """Collect outputs from different systems and score consensus."""
+    """Collect outputs from different systems and score consensus.
+
+    The :meth:`reset` method clears all registered outputs so the object can
+    be reused for a fresh consensus calculation.
+    """
 
     def __init__(self) -> None:
         self._outputs: Dict[str, List[str]] = {}
@@ -30,3 +34,7 @@ class CrossSystemConsensus:
     def has_converged(self, threshold: float = 1.0) -> bool:
         """Check whether consensus meets or exceeds ``threshold``."""
         return self.consensus() >= threshold
+
+    def reset(self) -> None:
+        """Clear all recorded outputs."""
+        self._outputs.clear()

--- a/tests/test_cross_system.py
+++ b/tests/test_cross_system.py
@@ -13,3 +13,16 @@ def test_consensus_scoring():
     assert consensus.consensus() == pytest.approx(2/3)
     assert not consensus.has_converged()
     assert consensus.has_converged(threshold=0.5)
+
+
+def test_reset_clears_outputs():
+    """Resetting removes all previously registered outputs."""
+    consensus = CrossSystemConsensus()
+    consensus.register("sys1", "a")
+    consensus.register("sys2", "b")
+    assert consensus.latest_outputs()
+
+    consensus.reset()
+
+    assert consensus.latest_outputs() == {}
+    assert consensus.consensus() == 0.0


### PR DESCRIPTION
## Summary
- allow `CrossSystemConsensus` to clear recorded outputs via new `reset` method
- document `reset` in class docstring
- test that `reset` removes all outputs and resets consensus score

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73780e740832197c0d06da2afa9b2